### PR TITLE
newアクション、editアクション遷移先調整

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,4 +1,5 @@
 class ProductsController < ApplicationController
+  before_action :authenticate_user!, only: [:new]
   before_action :parent,only:[:new,:create,:edit,:update]
   before_action :set_product, except: [:index, :new, :create,:search]
   before_action :category,only:[:edit,:update]
@@ -33,7 +34,10 @@ class ProductsController < ApplicationController
   end
 
   def edit
+    unless user_signed_in? && current_user.id == @product.user_id
+      redirect_to product_path(@product.id)
   end
+end
 
   def update
 


### PR DESCRIPTION
## what
手打ちで商品編集ページに遷移しようとする事が可能なのでコントローラーにidが違う場合、商品詳細ページに戻るコードを追加した
また、サインインをしていない場合、商品投稿ページに遷移できてしまうのでこれもコントローラーに遷移しないコードを追加
## why
他ユーザーが勝手に商品を編集できないようにするため
登録していなくても遷移はできても新規投稿ができないのは不親切だと思ったから