### PR TITLE
商品購入ページ、エラーメッセージ修正

### DIFF
--- a/app/assets/stylesheets/orders_new.scss
+++ b/app/assets/stylesheets/orders_new.scss
@@ -9,7 +9,14 @@
   min-height: 100vh;
   background-color: lightgrey;
 }
-
+.OrderErrorMessage{
+  font-size:16px;
+  font-size: initial;
+  font-weight: initial;
+  color:red;
+  margin-top: 15px;
+  text-align: center;
+}
 .Header {
   height: 70px;
   display: flex;

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -5,7 +5,9 @@
       %section.Product__List__Verification.NoFst--cld
         %h2.Contents
           購入内容の確認
-      = render 'layouts/notifications'
+      .OrderErrorMessage
+        - if flash[:error]
+          = flash[:error]
       %section.Product__List__Show.NoFst--cld
         .ShowForm
           .ShowForm__Image


### PR DESCRIPTION
## what
viewの = render 'layouts/notifications'の記述だと、他のメッセージ（ログイン時の文言）も表示されてしまうので、- if flash[:error]を利用してカードがない場合に現れるエラーメッセージのみ表記されるようにする
該当のメッセージをscssを利用してスタイリングを行う
## why
必要なエラーメッセージのみ表記したいので