### PR TITLE
一覧ページビュー崩れ、カテゴリーvalidation修正

### DIFF
--- a/app/assets/stylesheets/products.scss
+++ b/app/assets/stylesheets/products.scss
@@ -397,7 +397,6 @@ header {
         .ProductList {
           width: 220px;
           display: inline-block;
-          float: flex;
           .ProductLink {
             width: 200px;
             background-color: #fff;
@@ -423,6 +422,8 @@ header {
               padding: 16px;
               .name {
                 overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
                 line-height: 1.5;
                 font-size: 16px;
                 text-align: left;

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,7 +24,7 @@ class Product < ApplicationRecord
   validates :title, presence: true,length: { maximum: 40 }
   validates :price, presence: true,inclusion: {in: 300..9999999}
   validates :explanation, presence: true,length: { maximum: 1000 }
-  validates :category_id, presence: { message: "を選択してください"}
+  validates :category_id, {presence: { message: "を選択してください"}, numericality: { greater_than_or_equal_to:2 ,message: "を変更してください"}}
   validates :postal_prefectures_id,presence: { message: "を選択してください"}
   
 end 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -24,7 +24,7 @@ class Product < ApplicationRecord
   validates :title, presence: true,length: { maximum: 40 }
   validates :price, presence: true,inclusion: {in: 300..9999999}
   validates :explanation, presence: true,length: { maximum: 1000 }
-  validates :category_id, {presence: { message: "を選択してください"}, numericality: { greater_than_or_equal_to:2 ,message: "を変更してください"}}
+  validates :category_id, numericality: { greater_than_or_equal_to:2 ,message: "を選択してください"}
   validates :postal_prefectures_id,presence: { message: "を選択してください"}
   
 end 


### PR DESCRIPTION
# What
商品一覧ページの商品名部分が一定の文字数になると改行されてしまい、ビューが他のと崩れてしまうため修正
出品ページで保存失敗した時、親カテゴリーのみで保存可能になってしまう。
そのまま保存出来てしまうと詳細ページを開こうとするとエラーが起きてしまうので、productモデルのカテゴリーのvalidationを変更し、親カテゴリのみで保存出来ない様に修正
# why
詳細ページをエラー無く開ける様にするため
ビューの崩れの解消のため